### PR TITLE
Add a type for RTLCSS's default plugin export

### DIFF
--- a/types/rtlcss/index.d.ts
+++ b/types/rtlcss/index.d.ts
@@ -4,77 +4,90 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.3
 
-export interface MapOptions {
-    scope: string;
-    ignoreCase: boolean;
-    greedy?: boolean;
+import { Plugin } from 'postcss';
+
+declare namespace rtlcss {
+    interface MapOptions {
+        scope: string;
+        ignoreCase: boolean;
+        greedy?: boolean;
+    }
+
+    interface StringMap {
+        name: string;
+        priority: number;
+        exclusive?: boolean;
+        search: string|string[];
+        replace: string|string[];
+        options: MapOptions;
+    }
+
+    interface ConfigOptions {
+        /**
+         * Applies to CSS rules containing no directional properties,
+         * it will update the selector by applying String Map.
+         */
+        autoRename: boolean;
+        /**
+         * Ensures autoRename is applied only if pair exists.
+         */
+        autoRenameStrict: boolean;
+        /**
+         * An object map of disabled plugins directives,
+         * where keys are plugin names and value are object
+         * hash of disabled directives. e.g. {'rtlcss':{'config':true}}.
+         */
+        blacklist: object;
+        /**
+         * Removes directives comments from output CSS.
+         */
+        clean: boolean;
+        /**
+         * Fallback value for String Map options.
+         */
+        greedy: boolean;
+        /**
+         * Applies String Map to URLs. You can also target specific node types using an object literal.
+         * e.g. {'atrule': true, 'decl': false}.
+         */
+        processUrls: boolean|object;
+        /**
+         * The default array of String Map.
+         */
+        stringMap: StringMap[];
+        /**
+         * When enabled, flips background-position expressed in length units using calc.
+         */
+        useCalc: boolean;
+    }
+
+    interface HookOptions {
+        /**
+         * The function to be called before processing the CSS.
+         */
+        pre: () => void;
+        /**
+         * The function to be called after processing the CSS.
+         */
+        post: () => void;
+    }
+
+    interface ExportedAPI {
+        /**
+         * Creates a new RTLCSS instance, process the input and return its result.
+         */
+        process(
+            css: string, options?: object, plugins?: object|string[],
+            hooks?: HookOptions): string;
+
+        /**
+         * Creates a new instance of RTLCSS using the passed configuration object.
+         */
+        configure(config: ConfigOptions): object;
+    }
+
+    type RtlCss = Plugin<ConfigOptions> & ExportedAPI;
 }
 
-export interface StringMap {
-    name: string;
-    priority: number;
-    exclusive?: boolean;
-    search: string|string[];
-    replace: string|string[];
-    options: MapOptions;
-}
-
-export interface ConfigOptions {
-    /**
-     * Applies to CSS rules containing no directional properties,
-     * it will update the selector by applying String Map.
-     */
-    autoRename: boolean;
-    /**
-     * Ensures autoRename is applied only if pair exists.
-     */
-    autoRenameStrict: boolean;
-    /**
-     * An object map of disabled plugins directives,
-     * where keys are plugin names and value are object
-     * hash of disabled directives. e.g. {'rtlcss':{'config':true}}.
-     */
-    blacklist: object;
-    /**
-     * Removes directives comments from output CSS.
-     */
-    clean: boolean;
-    /**
-     * Fallback value for String Map options.
-     */
-    greedy: boolean;
-    /**
-     * Applies String Map to URLs. You can also target specific node types using an object literal.
-     * e.g. {'atrule': true, 'decl': false}.
-     */
-    processUrls: boolean|object;
-    /**
-     * The default array of String Map.
-     */
-    stringMap: StringMap[];
-    /**
-     * When enabled, flips background-position expressed in length units using calc.
-     */
-    useCalc: boolean;
-}
-
-export interface HookOptions {
-    /**
-     * The function to be called before processing the CSS.
-     */
-    pre: () => void;
-    /**
-     * The function to be called after processing the CSS.
-     */
-    post: () => void;
-}
-
-/**
- * Creates a new RTLCSS instance, process the input and return its result.
- */
-export function process(css: string, options?: object, plugins?: object|string[], hooks?: HookOptions): string;
-
-/**
- * Creates a new instance of RTLCSS using the passed configuration object.
- */
-export function configure(config: ConfigOptions): object;
+declare const rtlcss: rtlcss.RtlCss;
+export = rtlcss;

--- a/types/rtlcss/package.json
+++ b/types/rtlcss/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "7.x.x"
+    }
+}

--- a/types/rtlcss/rtlcss-tests.ts
+++ b/types/rtlcss/rtlcss-tests.ts
@@ -1,4 +1,5 @@
 import * as rtlcss from "rtlcss";
+import { Transformer } from 'postcss';
 
 rtlcss.process("body { direction:ltr; }");
 
@@ -25,3 +26,5 @@ const config = {
 };
 
 rtlcss.configure(config);
+
+const transformer: Transformer = rtlcss(config);


### PR DESCRIPTION
This is written to match the structure of the autoprefixer types.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nex3/rtlcss/blob/a2f9748b6dfa006f323ee8401343e1e433be62b3/lib/rtlcss.js#L13
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.